### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/tinted-software/egui_nodes/compare/v0.1.0...v0.1.1) - 2025-08-09
+
+### Fixed
+
+- *(deps)* update egui to 0.32.0
+- *(deps)* update all non-major dependencies to 0.31.1
+
+### Other
+
+- *(deps)* update actions/checkout digest to 8edcb1b
+- *(deps)* pin release-plz/action action to ccf6dd9
+- add release-plz
+- add git-cliff
+- *(deps)* update actions/checkout digest to 11bd719
+- update renovate.json
+- use stable rust in ci
+- migrate to ui builder
+- *(deps)* update all non-major dependencies to 0.29.0
 ## [0.1.0] - 2024-07-12
 
 ### 🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinted_egui_nodes"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Theo Paris <theo@tinted.dev>", "Cameron Haigh <cgwhaigh@gmail.com>"]
 edition = "2024"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tinted_egui_nodes`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/tinted-software/egui_nodes/compare/v0.1.0...v0.1.1) - 2025-08-09

### Fixed

- *(deps)* update egui to 0.32.0
- *(deps)* update all non-major dependencies to 0.31.1

### Other

- *(deps)* update actions/checkout digest to 8edcb1b
- *(deps)* pin release-plz/action action to ccf6dd9
- add release-plz
- add git-cliff
- *(deps)* update actions/checkout digest to 11bd719
- update renovate.json
- use stable rust in ci
- migrate to ui builder
- *(deps)* update all non-major dependencies to 0.29.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).