### PR TITLE
feat!: add node groups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: test suite
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 egui = "0.35.0"
-derivative = "2.2.0"
+educe = { version = "0.7.4", features = ["full"] }
 
 [dev-dependencies]
 eframe = "0.35.0"

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,162 @@
+//! Shared plain-data node/group definitions and constructor builders used by every
+//! example in this crate. Not part of the published library — `egui_nodes::NodeConstructor`
+//! / `GroupConstructor` are frame-scoped builders (their title/attribute callbacks borrow
+//! the current `Ui` pass) and can't be stored across frames, so examples instead keep this
+//! plain data around and turn it into fresh constructors every frame via [`build_node`] /
+//! [`build_group`].
+//!
+//! Each example only exercises a subset of this module (e.g. `simple` never builds a
+//! group, `groups` never uses a static attribute), so unused items are expected here.
+#![allow(dead_code)]
+use egui::Ui;
+use egui_nodes::{GroupArgs, GroupConstructor, NodeArgs, NodeConstructor, PinArgs};
+
+#[derive(Clone, Copy)]
+pub enum AttributeKind {
+    Input,
+    Output,
+    Static,
+}
+
+/// What an attribute row renders. `Label` is the common case (static, read-only text);
+/// `Widget` lets a node host any interactive egui control (slider, checkbox, text edit,
+/// button, ...) by owning whatever state the control mutates and rendering it each frame.
+pub enum AttributeContent {
+    Label(&'static str),
+    Widget(Box<dyn FnMut(&mut Ui) -> egui::Response>),
+}
+
+/// A single connectable (or non-connectable) attribute row on a node.
+pub struct Attribute {
+    pub id: usize,
+    pub kind: AttributeKind,
+    pub content: AttributeContent,
+    pub pin_args: PinArgs,
+}
+
+impl Attribute {
+    pub fn input(id: usize, label: &'static str, pin_args: PinArgs) -> Self {
+        Self {
+            id,
+            kind: AttributeKind::Input,
+            content: AttributeContent::Label(label),
+            pin_args,
+        }
+    }
+
+    pub fn output(id: usize, label: &'static str, pin_args: PinArgs) -> Self {
+        Self {
+            id,
+            kind: AttributeKind::Output,
+            content: AttributeContent::Label(label),
+            pin_args,
+        }
+    }
+
+    pub fn static_attr(id: usize, label: &'static str) -> Self {
+        Self {
+            id,
+            kind: AttributeKind::Static,
+            content: AttributeContent::Label(label),
+            pin_args: PinArgs::new(),
+        }
+    }
+
+    /// A non-connectable attribute row that renders an arbitrary, stateful egui control.
+    /// `render` owns (via capture) whatever value it edits, e.g. a slider closing over a
+    /// `f32` field stored elsewhere in the app.
+    pub fn static_widget(
+        id: usize,
+        render: impl FnMut(&mut Ui) -> egui::Response + 'static,
+    ) -> Self {
+        Self {
+            id,
+            kind: AttributeKind::Static,
+            content: AttributeContent::Widget(Box::new(render)),
+            pin_args: PinArgs::new(),
+        }
+    }
+
+    /// A connectable input attribute row that also renders an arbitrary control (e.g. a
+    /// numeric pin that's still editable by hand when nothing is plugged into it).
+    pub fn input_widget(
+        id: usize,
+        pin_args: PinArgs,
+        render: impl FnMut(&mut Ui) -> egui::Response + 'static,
+    ) -> Self {
+        Self {
+            id,
+            kind: AttributeKind::Input,
+            content: AttributeContent::Widget(Box::new(render)),
+            pin_args,
+        }
+    }
+
+    /// A connectable output attribute row that also renders an arbitrary control (e.g. a
+    /// numeric pin that's still editable by hand when nothing is plugged into it).
+    pub fn output_widget(
+        id: usize,
+        pin_args: PinArgs,
+        render: impl FnMut(&mut Ui) -> egui::Response + 'static,
+    ) -> Self {
+        Self {
+            id,
+            kind: AttributeKind::Output,
+            content: AttributeContent::Widget(Box::new(render)),
+            pin_args,
+        }
+    }
+}
+
+/// Persistent, app-owned description of a node.
+pub struct Node {
+    pub id: usize,
+    pub title: String,
+    pub origin: egui::Pos2,
+    pub args: NodeArgs,
+    pub attributes: Vec<Attribute>,
+}
+
+/// Persistent, app-owned description of a comment/group box.
+pub struct Group {
+    pub id: usize,
+    pub title: String,
+    pub origin: egui::Pos2,
+    pub size: egui::Vec2,
+    pub args: GroupArgs,
+    pub member_ids: Vec<usize>,
+}
+
+/// Build a fresh, frame-scoped `NodeConstructor` from a stored `Node`. Takes `&mut Node`
+/// (rather than `&Node`) because `AttrContent::Widget` closures are `FnMut` — a slider,
+/// checkbox, etc. needs mutable access to the value it edits every time it's drawn.
+pub fn build_node(node: &mut Node) -> NodeConstructor<'_> {
+    let title = node.title.clone();
+    let mut ctor = NodeConstructor::new(node.id, node.args)
+        .with_origin(node.origin)
+        .with_title(move |ui: &mut Ui| ui.label(title));
+    for attr in &mut node.attributes {
+        let id = attr.id;
+        let pin_args = attr.pin_args;
+        let content = &mut attr.content;
+        let render = move |ui: &mut Ui| match content {
+            AttributeContent::Label(text) => ui.label(*text),
+            AttributeContent::Widget(render) => render(ui),
+        };
+        ctor = match attr.kind {
+            AttributeKind::Input => ctor.with_input_attribute(id, pin_args, render),
+            AttributeKind::Output => ctor.with_output_attribute(id, pin_args, render),
+            AttributeKind::Static => ctor.with_static_attribute(id, render),
+        };
+    }
+    ctor
+}
+
+/// Build a fresh, frame-scoped `GroupConstructor` from a stored `GroupDef`.
+pub fn build_group(group: &Group) -> GroupConstructor<'_> {
+    GroupConstructor::new(group.id, group.args)
+        .with_title(move |ui: &mut Ui| ui.label(&group.title))
+        .with_nodes(group.member_ids.iter().copied())
+        .with_origin(group.origin)
+        .with_size(group.size)
+}

--- a/examples/groups.rs
+++ b/examples/groups.rs
@@ -1,0 +1,152 @@
+//! Demonstrates a larger graph organized into Unreal-Engine-style comment/group boxes,
+//! showing how nodes are dragged and resized together as members of a group.
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{Attribute, Group, Node, build_group, build_node};
+use eframe::{self, egui};
+use egui_nodes::{Context, GroupArgs, GroupConstructor, LinkArgs, NodeArgs, NodeConstructor};
+
+const GROUP_COUNT: usize = 5;
+const NODES_PER_GROUP: usize = 6;
+const GROUP_SPACING_X: f32 = 260.0;
+const NODE_SPACING_Y: f32 = 70.0;
+const GROUP_PADDING_TOP: f32 = 50.0;
+
+/// Node ids are `group_idx * NODES_PER_GROUP + node_in_group`, so they stay dense and
+/// collision-free across every group. Group ids live in a disjoint range above them.
+fn node_id(group_idx: usize, node_in_group: usize) -> usize {
+    group_idx * NODES_PER_GROUP + node_in_group
+}
+
+fn group_id(group_idx: usize) -> usize {
+    100_000 + group_idx
+}
+
+/// Each node has one input pin and one output pin; pin ids are derived from the node id
+/// so they never collide with pin ids belonging to other nodes.
+fn input_pin_id(id: usize) -> usize {
+    id * 2
+}
+
+fn output_pin_id(id: usize) -> usize {
+    id * 2 + 1
+}
+
+struct MyApp {
+    ctx: Context,
+    nodes: Vec<Node>,
+    groups: Vec<Group>,
+    links: Vec<(usize, usize)>,
+}
+
+impl Default for MyApp {
+    fn default() -> Self {
+        let mut nodes = Vec::new();
+        let mut groups = Vec::new();
+        // Chain every node's output to the next node's input, both within a group and
+        // across the gap between consecutive groups, so the whole graph is one long path.
+        let mut links = Vec::new();
+        let mut prev: Option<usize> = None;
+
+        for group_idx in 0..GROUP_COUNT {
+            let mut member_ids = Vec::with_capacity(NODES_PER_GROUP);
+            for node_in_group in 0..NODES_PER_GROUP {
+                let id = node_id(group_idx, node_in_group);
+                if let Some(prev_id) = prev {
+                    links.push((output_pin_id(prev_id), input_pin_id(id)));
+                }
+                prev = Some(id);
+                member_ids.push(id);
+
+                nodes.push(Node {
+                    id,
+                    title: format!("Node {group_idx}.{node_in_group}"),
+                    origin: egui::pos2(
+                        50.0 + group_idx as f32 * GROUP_SPACING_X,
+                        30.0 + GROUP_PADDING_TOP + node_in_group as f32 * NODE_SPACING_Y,
+                    ),
+                    args: NodeArgs::new(),
+                    attributes: vec![
+                        Attribute::input(input_pin_id(id), "in", Default::default()),
+                        Attribute::output(output_pin_id(id), "out", Default::default()),
+                    ],
+                });
+            }
+
+            let height = GROUP_PADDING_TOP + NODES_PER_GROUP as f32 * NODE_SPACING_Y + 20.0;
+            groups.push(Group {
+                id: group_id(group_idx),
+                title: format!("Group {group_idx}"),
+                origin: egui::pos2(30.0 + group_idx as f32 * GROUP_SPACING_X, 30.0),
+                size: egui::vec2(220.0, height),
+                args: GroupArgs {
+                    outline: Some(egui::Color32::LIGHT_BLUE),
+                    ..GroupArgs::new()
+                },
+                member_ids,
+            });
+        }
+
+        Self {
+            ctx: Context::default(),
+            nodes,
+            groups,
+            links,
+        }
+    }
+}
+
+fn example_graph(
+    ctx: &mut Context,
+    nodes: &mut [Node],
+    groups: &[Group],
+    links: &mut Vec<(usize, usize)>,
+    ui: &mut egui::Ui,
+) {
+    let group_constructors: Vec<GroupConstructor> = groups.iter().map(build_group).collect();
+    let node_constructors: Vec<NodeConstructor> = nodes.iter_mut().map(build_node).collect();
+
+    ctx.show(
+        group_constructors,
+        node_constructors,
+        links.iter().enumerate().map(|(i, (start, end))| (i, *start, *end, LinkArgs::default())),
+        ui,
+    );
+
+    if let Some(idx) = ctx.link_destroyed() {
+        links.remove(idx);
+    }
+
+    if let Some((start, end, _)) = ctx.link_created() {
+        links.push((start, end))
+    }
+}
+
+impl eframe::App for MyApp {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ui, |ui| {
+            ui.heading(format!(
+                "{} nodes across {} groups",
+                self.nodes.len(),
+                self.groups.len()
+            ));
+            example_graph(
+                &mut self.ctx,
+                &mut self.nodes,
+                &self.groups,
+                &mut self.links,
+                ui,
+            );
+        });
+    }
+}
+
+fn main() {
+    eframe::run_native(
+        "egui_nodes groups example",
+        eframe::NativeOptions::default(),
+        Box::new(|_cc| Ok(Box::<MyApp>::default())),
+    )
+    .unwrap();
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,51 +1,94 @@
-use eframe::{self, egui};
-use egui_nodes::{Context, LinkArgs, NodeArgs, NodeConstructor, PinArgs, PinShape};
+#[path = "common/mod.rs"]
+mod common;
 
-#[derive(Default)]
+use common::{Attribute, Node, build_node};
+use eframe::{self, egui};
+use egui_nodes::{
+    Context, GroupConstructor, LinkArgs, NodeArgs, NodeConstructor, PinArgs, PinShape,
+};
+
 struct MyApp {
     ctx: Context,
+    nodes: Vec<Node>,
     links: Vec<(usize, usize)>,
 }
 
-pub fn example_graph(ctx: &mut Context, links: &mut Vec<(usize, usize)>, ui: &mut egui::Ui) {
-    // add nodes with attributes
-    let nodes = vec![
-        NodeConstructor::new(
-            0,
-            NodeArgs {
-                outline: Some(egui::Color32::LIGHT_BLUE),
-                ..Default::default()
+impl Default for MyApp {
+    fn default() -> Self {
+        let nodes = vec![
+            Node {
+                id: 0,
+                title: "Example Node A".to_string(),
+                origin: [50.0, 150.0].into(),
+                args: NodeArgs {
+                    outline: Some(egui::Color32::LIGHT_BLUE),
+                    ..NodeArgs::new()
+                },
+                attributes: vec![
+                    Attribute::input(
+                        0,
+                        "Input",
+                        PinArgs {
+                            shape: PinShape::Triangle,
+                            ..PinArgs::new()
+                        },
+                    ),
+                    Attribute::static_attr(1, "Can't Connect to Me"),
+                    Attribute::output(
+                        2,
+                        "Output",
+                        PinArgs {
+                            shape: PinShape::TriangleFilled,
+                            ..PinArgs::new()
+                        },
+                    ),
+                    {
+                        let mut gain = 0.5f32;
+                        Attribute::static_widget(6, move |ui| {
+                            ui.add(
+                                egui::Slider::new(&mut gain, 0.0..=1.0)
+                                    .show_value(false)
+                                    .text("Gain"),
+                            )
+                        })
+                    },
+                    {
+                        let mut enabled = true;
+                        Attribute::static_widget(7, move |ui| ui.checkbox(&mut enabled, "Enabled"))
+                    },
+                ],
             },
-        )
-        .with_origin([50.0, 150.0].into())
-        .with_title(|ui| ui.label("Example Node A"))
-        .with_input_attribute(
-            0,
-            PinArgs {
-                shape: PinShape::Triangle,
-                ..Default::default()
+            Node {
+                id: 1,
+                title: "Example Node B".to_string(),
+                origin: [225.0, 150.0].into(),
+                args: NodeArgs::new(),
+                attributes: vec![
+                    Attribute::static_attr(3, "Can't Connect to Me"),
+                    Attribute::output(4, "Output", PinArgs::new()),
+                    Attribute::input(5, "Input", PinArgs::new()),
+                ],
             },
-            |ui| ui.label("Input"),
-        )
-        .with_static_attribute(1, |ui| ui.label("Can't Connect to Me"))
-        .with_output_attribute(
-            2,
-            PinArgs {
-                shape: PinShape::TriangleFilled,
-                ..Default::default()
-            },
-            |ui| ui.label("Output"),
-        ),
-        NodeConstructor::new(1, Default::default())
-            .with_origin([225.0, 150.0].into())
-            .with_title(|ui| ui.label("Example Node B"))
-            .with_static_attribute(3, |ui| ui.label("Can't Connect to Me"))
-            .with_output_attribute(4, Default::default(), |ui| ui.label("Output"))
-            .with_input_attribute(5, Default::default(), |ui| ui.label("Input")),
-    ];
+        ];
+        Self {
+            ctx: Context::default(),
+            nodes,
+            links: Vec::new(),
+        }
+    }
+}
+
+fn example_graph(
+    ctx: &mut Context,
+    nodes: &mut [Node],
+    links: &mut Vec<(usize, usize)>,
+    ui: &mut egui::Ui,
+) {
+    let node_constructors: Vec<NodeConstructor> = nodes.iter_mut().map(build_node).collect();
 
     ctx.show(
-        nodes,
+        Vec::<GroupConstructor>::new(),
+        node_constructors,
         links.iter().enumerate().map(|(i, (start, end))| (i, *start, *end, LinkArgs::default())),
         ui,
     );
@@ -63,9 +106,9 @@ pub fn example_graph(ctx: &mut Context, links: &mut Vec<(usize, usize)>, ui: &mu
 
 impl eframe::App for MyApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("My egui Application");
-            example_graph(&mut self.ctx, &mut self.links, ui);
+            example_graph(&mut self.ctx, &mut self.nodes, &mut self.links, ui);
         });
     }
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,0 +1,175 @@
+use super::*;
+use derivative::Derivative;
+
+#[derive(Default, Clone, Copy, Debug)]
+/// The Style of a Group. If feilds are None then the Context style is used
+pub struct GroupArgs {
+    pub background: Option<egui::Color32>,
+    pub background_hovered: Option<egui::Color32>,
+    pub background_selected: Option<egui::Color32>,
+    pub outline: Option<egui::Color32>,
+    pub titlebar: Option<egui::Color32>,
+    pub titlebar_hovered: Option<egui::Color32>,
+    pub titlebar_selected: Option<egui::Color32>,
+    pub corner_rounding: Option<f32>,
+    pub padding: Option<egui::Vec2>,
+    pub border_thickness: Option<f32>,
+}
+
+impl GroupArgs {
+    pub const fn new() -> Self {
+        Self {
+            background: None,
+            background_hovered: None,
+            background_selected: None,
+            outline: None,
+            titlebar: None,
+            titlebar_hovered: None,
+            titlebar_selected: None,
+            corner_rounding: None,
+            padding: None,
+            border_thickness: None,
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct GroupDataColorStyle {
+    pub background: egui::Color32,
+    pub background_hovered: egui::Color32,
+    pub background_selected: egui::Color32,
+    pub outline: egui::Color32,
+    pub titlebar: egui::Color32,
+    pub titlebar_hovered: egui::Color32,
+    pub titlebar_selected: egui::Color32,
+}
+
+#[derive(Default, Debug)]
+pub struct GroupDataLayoutStyle {
+    pub corner_rounding: f32,
+    pub padding: egui::Vec2,
+    pub border_thickness: f32,
+}
+
+/// Comment-box style node group. Members are dragged together when the
+/// group's title bar is dragged. Membership is explicit (caller-supplied
+/// each frame via [`GroupConstructor::with_nodes`]), not spatial containment.
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub(crate) struct GroupData {
+    pub id: usize,
+    pub origin: egui::Pos2,
+    pub size: egui::Vec2,
+    pub rect: egui::Rect,
+    pub title_bar_rect: egui::Rect,
+    #[derivative(Debug = "ignore")]
+    pub color_style: GroupDataColorStyle,
+    pub layout_style: GroupDataLayoutStyle,
+    pub member_node_ids: Vec<usize>,
+    pub member_node_indices: Vec<usize>,
+    pub draggable: bool,
+    pub resizable: bool,
+    #[derivative(Debug = "ignore")]
+    pub titlebar_shape: Option<egui::layers::ShapeIdx>,
+    #[derivative(Debug = "ignore")]
+    pub background_shape: Option<egui::layers::ShapeIdx>,
+    #[derivative(Debug = "ignore")]
+    pub outline_shape: Option<egui::layers::ShapeIdx>,
+}
+
+impl GroupData {
+    pub fn new(id: usize) -> Self {
+        Self {
+            id,
+            origin: [100.0; 2].into(),
+            size: [200.0, 150.0].into(),
+            rect: [[0.0; 2].into(); 2].into(),
+            title_bar_rect: [[0.0; 2].into(); 2].into(),
+            color_style: Default::default(),
+            layout_style: Default::default(),
+            member_node_ids: Default::default(),
+            member_node_indices: Default::default(),
+            draggable: true,
+            resizable: true,
+            titlebar_shape: None,
+            background_shape: None,
+            outline_shape: None,
+        }
+    }
+}
+
+impl Default for GroupData {
+    fn default() -> Self {
+        Self::new(0)
+    }
+}
+
+impl Id for GroupData {
+    fn id(&self) -> usize {
+        self.id
+    }
+    fn new(id: usize) -> Self {
+        GroupData::new(id)
+    }
+}
+
+/// Used to construct a comment-box node group and stores the relevant ui code for its title.
+/// Groups are always rendered behind nodes; dragging the group's title bar drags every
+/// member node along with it.
+#[derive(Derivative, Default)]
+#[derivative(Debug)]
+#[allow(clippy::type_complexity)]
+pub struct GroupConstructor<'a> {
+    pub(crate) id: usize,
+    #[derivative(Debug = "ignore")]
+    pub(crate) title: Option<Box<dyn FnOnce(&mut egui::Ui) -> egui::Response + 'a>>,
+    pub(crate) member_ids: Vec<usize>,
+    pub(crate) pos: Option<egui::Pos2>,
+    pub(crate) size: Option<egui::Vec2>,
+    pub(crate) args: GroupArgs,
+}
+
+impl<'a> GroupConstructor<'a> {
+    /// Create a new group to be displayed in a Context.
+    /// id should be the same accross frames and should not be the same as any other currently used group
+    pub fn new(id: usize, args: GroupArgs) -> Self {
+        Self {
+            id,
+            args,
+            ..Default::default()
+        }
+    }
+
+    /// Add a title to a group
+    pub fn with_title(mut self, title: impl FnOnce(&mut egui::Ui) -> egui::Response + 'a) -> Self {
+        self.title.replace(Box::new(title));
+        self
+    }
+
+    /// Add node ids that belong to this group. Dragging the group's title bar moves
+    /// every listed member node along with it. Ids that don't match a currently
+    /// displayed node are silently ignored.
+    pub fn with_nodes(mut self, ids: impl IntoIterator<Item = usize>) -> Self {
+        self.member_ids.extend(ids);
+        self
+    }
+
+    /// Set the position of the group in screen space when it is first created.
+    /// To modify it after creation use one of the set_group_pos methods of the Context
+    pub fn with_origin(mut self, origin: egui::Pos2) -> Self {
+        self.pos.replace(origin);
+        self
+    }
+
+    /// Set the size of the group when it is first created.
+    /// To modify it after creation use set_group_size on the Context
+    pub fn with_size(mut self, size: egui::Vec2) -> Self {
+        self.size.replace(size);
+        self
+    }
+
+    /// Get the id of this GroupConstructor
+    pub fn id(&self) -> usize {
+        self.id
+    }
+}

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,5 +1,5 @@
 use super::*;
-use derivative::Derivative;
+use educe::Educe;
 
 #[derive(Default, Clone, Copy, Debug)]
 /// The Style of a Group. If feilds are None then the Context style is used
@@ -54,26 +54,26 @@ pub struct GroupDataLayoutStyle {
 /// Comment-box style node group. Members are dragged together when the
 /// group's title bar is dragged. Membership is explicit (caller-supplied
 /// each frame via [`GroupConstructor::with_nodes`]), not spatial containment.
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Educe)]
+#[educe(Debug)]
 pub(crate) struct GroupData {
     pub id: usize,
     pub origin: egui::Pos2,
     pub size: egui::Vec2,
     pub rect: egui::Rect,
     pub title_bar_rect: egui::Rect,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub color_style: GroupDataColorStyle,
     pub layout_style: GroupDataLayoutStyle,
     pub member_node_ids: Vec<usize>,
     pub member_node_indices: Vec<usize>,
     pub draggable: bool,
     pub resizable: bool,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub titlebar_shape: Option<egui::layers::ShapeIdx>,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub background_shape: Option<egui::layers::ShapeIdx>,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub outline_shape: Option<egui::layers::ShapeIdx>,
 }
 
@@ -116,12 +116,12 @@ impl Id for GroupData {
 /// Used to construct a comment-box node group and stores the relevant ui code for its title.
 /// Groups are always rendered behind nodes; dragging the group's title bar drags every
 /// member node along with it.
-#[derive(Derivative, Default)]
-#[derivative(Debug)]
+#[derive(Educe, Default)]
+#[educe(Debug)]
 #[allow(clippy::type_complexity)]
 pub struct GroupConstructor<'a> {
     pub(crate) id: usize,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub(crate) title: Option<Box<dyn FnOnce(&mut egui::Ui) -> egui::Response + 'a>>,
     pub(crate) member_ids: Vec<usize>,
     pub(crate) pos: Option<egui::Pos2>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //! }
 //! ```
 
-use derivative::Derivative;
+use educe::Educe;
 use egui::UiBuilder;
 use std::collections::HashMap;
 
@@ -69,24 +69,22 @@ pub use {
 };
 
 /// The Context that tracks the state of the node editor
-#[derive(Derivative)]
-#[derivative(Default, Debug)]
+#[derive(Educe)]
+#[educe(Debug, Default)]
 pub struct Context {
-    node_idx_submission_order: Vec<usize>,
     node_indices_overlapping_with_mouse: Vec<usize>,
     occluded_pin_indices: Vec<usize>,
 
     canvas_origin_screen_space: egui::Vec2,
-    #[derivative(Default(value = "[[0.0; 2].into(); 2].into()"))]
+    #[educe(Default(expression = [[0.0; 2].into(); 2].into()))]
     canvas_rect_screen_space: egui::Rect,
 
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub io: IO,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub style: Style,
     color_modifier_stack: Vec<ColorStyleElement>,
     style_modifier_stack: Vec<StyleElement>,
-    text_buffer: String,
 
     current_attribute_flags: usize,
     attribute_flag_stack: Vec<usize>,
@@ -96,7 +94,6 @@ pub struct Context {
     hovered_link_idx: Option<usize>,
     hovered_pin_index: Option<usize>,
     hovered_pin_flags: usize,
-    ui_element_hovered: bool,
 
     deleted_link_idx: Option<usize>,
     snap_link_idx: Option<usize>,
@@ -120,8 +117,6 @@ pub struct Context {
     nodes: ObjectPool<NodeData>,
     pins: ObjectPool<PinData>,
     links: ObjectPool<LinkData>,
-    nodes_map: HashMap<usize, usize>,
-    nodes_free: Vec<usize>,
 
     node_depth_order: Vec<usize>,
     node_draw_order_scratch: Vec<usize>,
@@ -139,7 +134,7 @@ pub struct Context {
     selected_node_indices: Vec<usize>,
     selected_link_indices: Vec<usize>,
 
-    #[derivative(Default(value = "ClickInteractionType::None"))]
+    #[educe(Default(expression = ClickInteractionType::None))]
     click_interaction_type: ClickInteractionType,
     click_interaction_state: ClickInteractionState,
 }
@@ -1600,20 +1595,20 @@ enum LinkCreationType {
     FromDetach,
 }
 
-#[derive(Derivative, Debug)]
-#[derivative(Default)]
+#[derive(Educe, Debug)]
+#[educe(Default)]
 struct ClickInteractionStateLinkCreation {
     start_pin_idx: usize,
     end_pin_index: Option<usize>,
-    #[derivative(Default(value = "LinkCreationType::Standard"))]
+    #[educe(Default(expression = LinkCreationType::Standard))]
     link_creation_type: LinkCreationType,
 }
 
-#[derive(Derivative, Debug)]
-#[derivative(Default)]
+#[derive(Educe, Debug)]
+#[educe(Default)]
 struct ClickInteractionState {
     link_creation: ClickInteractionStateLinkCreation,
-    #[derivative(Default(value = "[[0.0; 2].into(); 2].into()"))]
+    #[educe(Default(expression = [[0.0; 2].into(); 2].into()))]
     box_selection: egui::Rect,
 }
 
@@ -1642,19 +1637,19 @@ impl StyleElement {
 }
 
 /// This controls the modifers needed for certain mouse interactions
-#[derive(Derivative, Debug)]
-#[derivative(Default)]
+#[derive(Educe, Debug)]
+#[educe(Default)]
 pub struct IO {
     /// The Modfier that needs to pressed to pan the editor
-    #[derivative(Default(value = "Modifiers::None"))]
+    #[educe(Default(expression = Modifiers::None))]
     pub emulate_three_button_mouse: Modifiers,
 
     // The Modifier that needs to be pressed to detatch a link instead of creating a new one
-    #[derivative(Default(value = "Modifiers::None"))]
+    #[educe(Default(expression = Modifiers::None))]
     pub link_detatch_with_modifier_click: Modifiers,
 
     // The mouse button that pans the editor. Should probably not be set to Primary.
-    #[derivative(Default(value = "Some(egui::PointerButton::Middle)"))]
+    #[educe(Default(expression = Some(egui::PointerButton::Middle)))]
     pub alt_mouse_button: Option<egui::PointerButton>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! Here is the basic usage:
 //! ``` rust
-//! use egui_nodes::{Context, NodeConstructor, LinkArgs};
+//! use egui_nodes::{Context, NodeConstructor, GroupConstructor, LinkArgs};
 //! use egui::Ui;
 //!
 //! pub fn example_graph(ctx: &mut Context, links: &mut Vec<(usize, usize)>, ui: &mut Ui) {
@@ -23,9 +23,11 @@
 //!             .with_output_attribute(4, Default::default(), |ui| ui.label("Output"))
 //!             .with_input_attribute(5, Default::default(), |ui| ui.label("Input"))
 //!     ];
+//!     let groups: Vec<GroupConstructor> = vec![];
 //!
 //!     // add them to the ui
 //!     ctx.show(
+//!         groups,
 //!         nodes,
 //!         links.iter().enumerate().map(|(i, (start, end))| (i, *start, *end, LinkArgs::default())),
 //!         ui
@@ -47,16 +49,19 @@ use derivative::Derivative;
 use egui::UiBuilder;
 use std::collections::HashMap;
 
+mod group;
 mod link;
 mod node;
 mod pin;
 mod style;
 
+use group::*;
 use link::*;
 use node::*;
 use pin::*;
 
 pub use {
+    group::{GroupArgs, GroupConstructor},
     link::LinkArgs,
     node::{NodeArgs, NodeConstructor},
     pin::{AttributeFlags, PinArgs, PinShape},
@@ -119,6 +124,15 @@ pub struct Context {
     nodes_free: Vec<usize>,
 
     node_depth_order: Vec<usize>,
+    node_draw_order_scratch: Vec<usize>,
+
+    groups: ObjectPool<GroupData>,
+    group_depth_order: Vec<usize>,
+    group_draw_order_scratch: Vec<usize>,
+    hovered_group_index: Option<usize>,
+    hovered_group_resize_handle: bool,
+    interactive_group_index: Option<usize>,
+    selected_group_indices: Vec<usize>,
 
     panning: egui::Vec2,
 
@@ -134,6 +148,7 @@ impl Context {
     /// Displays the current state of the editor on a give Egui Ui as well as updating user input to the context
     pub fn show<'a>(
         &mut self,
+        groups: impl IntoIterator<Item = GroupConstructor<'a>>,
         nodes: impl IntoIterator<Item = NodeConstructor<'a>>,
         links: impl IntoIterator<Item = (usize, usize, usize, LinkArgs)>,
         ui: &mut egui::Ui,
@@ -145,10 +160,12 @@ impl Context {
             self.nodes.reset();
             self.pins.reset();
             self.links.reset();
+            self.groups.reset();
 
             self.hovered_node_index.take();
             self.interactive_node_index.take();
             self.hovered_link_idx.take();
+            self.hovered_group_index.take();
             self.hovered_pin_flags = AttributeFlags::None as usize;
             self.deleted_link_idx.take();
             self.snap_link_idx.take();
@@ -165,6 +182,16 @@ impl Context {
                 UiBuilder::new()
                     .max_rect(self.canvas_rect_screen_space)
                     .layout(egui::Layout::top_down(egui::Align::Center)),
+            );
+            // Claim the whole-canvas click/drag sense *before* any node/pin/attribute
+            // widgets are added below. egui's hit-test prefers the most-recently-registered
+            // widget under the pointer; registering this background sense first ensures
+            // interactive attribute widgets (checkboxes, sliders, ...) added afterward win
+            // ownership of clicks landing on them instead of this canvas catch-all.
+            let response = ui.interact(
+                self.canvas_rect_screen_space,
+                ui.id().with("Input"),
+                egui::Sense::click_and_drag(),
             );
             {
                 let ui = &mut ui;
@@ -189,18 +216,25 @@ impl Context {
                     .into_iter()
                     .map(|x| (self.node_pool_find_or_create_index(x.id, x.pos), x))
                     .collect::<HashMap<_, _>>();
-                for idx in self.node_depth_order.clone() {
+                for i in 0..self.node_depth_order.len() {
+                    let idx = self.node_depth_order[i];
                     if let Some(node_builder) = nodes.remove(&idx) {
                         self.add_node(idx, node_builder, ui);
                     }
                 }
+
+                let mut groups = groups
+                    .into_iter()
+                    .map(|x| (self.group_pool_find_or_create_index(x.id, x.pos, x.size), x))
+                    .collect::<HashMap<_, _>>();
+                for i in 0..self.group_depth_order.len() {
+                    let idx = self.group_depth_order[i];
+                    if let Some(group_builder) = groups.remove(&idx) {
+                        self.add_group(idx, group_builder, ui);
+                    }
+                }
             }
-            let response = ui.interact(
-                self.canvas_rect_screen_space,
-                ui.id().with("Input"),
-                egui::Sense::click_and_drag(),
-            );
-            let io = ui.ctx().input(|i| i.clone());
+            let (pointer, modifiers) = ui.ctx().input(|i| (i.pointer.clone(), i.modifiers));
             let mouse_pos = if let Some(mouse_pos) = response.hover_pos() {
                 self.mouse_in_canvas = true;
                 mouse_pos
@@ -210,7 +244,7 @@ impl Context {
             };
             self.mouse_delta = mouse_pos - self.mouse_pos;
             self.mouse_pos = mouse_pos;
-            let left_mouse_clicked = io.pointer.button_down(egui::PointerButton::Primary);
+            let left_mouse_clicked = pointer.button_down(egui::PointerButton::Primary);
             self.left_mouse_released =
                 (self.left_mouse_clicked || self.left_mouse_dragging) && !left_mouse_clicked;
             self.left_mouse_dragging =
@@ -218,14 +252,14 @@ impl Context {
             self.left_mouse_clicked =
                 left_mouse_clicked && !(self.left_mouse_clicked || self.left_mouse_dragging);
 
-            let alt_mouse_clicked = self.io.emulate_three_button_mouse.is_active(&io.modifiers)
-                || self.io.alt_mouse_button.is_some_and(|x| io.pointer.button_down(x));
+            let alt_mouse_clicked = self.io.emulate_three_button_mouse.is_active(&modifiers)
+                || self.io.alt_mouse_button.is_some_and(|x| pointer.button_down(x));
             self.alt_mouse_dragging =
                 (self.alt_mouse_clicked || self.alt_mouse_dragging) && alt_mouse_clicked;
             self.alt_mouse_clicked =
                 alt_mouse_clicked && !(self.alt_mouse_clicked || self.alt_mouse_dragging);
             self.link_detatch_with_modifier_click =
-                self.io.link_detatch_with_modifier_click.is_active(&io.modifiers);
+                self.io.link_detatch_with_modifier_click.is_active(&modifiers);
             {
                 let ui = &mut ui;
                 if self.mouse_in_canvas {
@@ -239,16 +273,32 @@ impl Context {
                     if self.hovered_node_index.is_none() {
                         self.resolve_hovered_link();
                     }
+
+                    if self.hovered_node_index.is_none() && self.hovered_link_idx.is_none() {
+                        self.resolve_hovered_group();
+                    }
                 }
 
-                for node_idx in self.node_depth_order.clone() {
+                self.group_draw_order_scratch.clear();
+                self.group_draw_order_scratch.extend_from_slice(&self.group_depth_order);
+                for i in 0..self.group_draw_order_scratch.len() {
+                    let idx = self.group_draw_order_scratch[i];
+                    if self.groups.in_use[idx] {
+                        self.draw_group(idx, ui);
+                    }
+                }
+
+                self.node_draw_order_scratch.clear();
+                self.node_draw_order_scratch.extend_from_slice(&self.node_depth_order);
+                for i in 0..self.node_draw_order_scratch.len() {
+                    let node_idx = self.node_draw_order_scratch[i];
                     if self.nodes.in_use[node_idx] {
                         self.draw_node(node_idx, ui);
                     }
                 }
 
-                for (link_idx, in_use) in self.links.in_use.clone().into_iter().enumerate() {
-                    if in_use {
+                for link_idx in 0..self.links.in_use.len() {
+                    if self.links.in_use[link_idx] {
                         self.draw_link(link_idx, ui);
                     }
                 }
@@ -262,6 +312,7 @@ impl Context {
                 self.node_pool_update();
                 self.pins.update();
                 self.links.update();
+                self.group_pool_update();
             }
             ui.painter().rect_stroke(
                 self.canvas_rect_screen_space,
@@ -487,6 +538,69 @@ impl Context {
     pub fn get_node_dimensions(&self, id: usize) -> Option<egui::Vec2> {
         self.nodes.find(id).map(|x| self.nodes.pool[x].rect.size())
     }
+
+    pub fn set_group_pos_screen_space(&mut self, group_id: usize, screen_space_pos: egui::Pos2) {
+        let idx = self.group_pool_find_or_create_index(group_id, None, None);
+        self.groups.pool[idx].origin = self.screen_space_to_grid_space(screen_space_pos);
+    }
+
+    pub fn set_group_pos_editor_space(&mut self, group_id: usize, editor_space_pos: egui::Pos2) {
+        let idx = self.group_pool_find_or_create_index(group_id, None, None);
+        self.groups.pool[idx].origin = self.editor_space_to_grid_spcae(editor_space_pos);
+    }
+
+    pub fn set_group_pos_grid_space(&mut self, group_id: usize, grid_pos: egui::Pos2) {
+        let idx = self.group_pool_find_or_create_index(group_id, None, None);
+        self.groups.pool[idx].origin = grid_pos;
+    }
+
+    pub fn get_group_pos_screen_space(&self, group_id: usize) -> Option<egui::Pos2> {
+        self.groups
+            .find(group_id)
+            .map(|x| self.grid_space_to_screen_space(self.groups.pool[x].origin))
+    }
+
+    pub fn get_group_pos_editor_space(&self, group_id: usize) -> Option<egui::Pos2> {
+        self.groups
+            .find(group_id)
+            .map(|x| self.grid_space_to_editor_spcae(self.groups.pool[x].origin))
+    }
+
+    pub fn get_group_pos_grid_space(&self, group_id: usize) -> Option<egui::Pos2> {
+        self.groups.find(group_id).map(|x| self.groups.pool[x].origin)
+    }
+
+    pub fn set_group_draggable(&mut self, group_id: usize, draggable: bool) {
+        let idx = self.group_pool_find_or_create_index(group_id, None, None);
+        self.groups.pool[idx].draggable = draggable;
+    }
+
+    pub fn set_group_resizable(&mut self, group_id: usize, resizable: bool) {
+        let idx = self.group_pool_find_or_create_index(group_id, None, None);
+        self.groups.pool[idx].resizable = resizable;
+    }
+
+    pub fn get_group_size(&self, group_id: usize) -> Option<egui::Vec2> {
+        self.groups.find(group_id).map(|x| self.groups.pool[x].size)
+    }
+
+    pub fn set_group_size(&mut self, group_id: usize, size: egui::Vec2) {
+        let idx = self.group_pool_find_or_create_index(group_id, None, None);
+        self.groups.pool[idx].size = size;
+    }
+
+    /// Check if there is a group that is hovered by the pointer
+    pub fn group_hovered(&self) -> Option<usize> {
+        self.hovered_group_index.map(|x| self.groups.pool[x].id)
+    }
+
+    pub fn get_selected_groups(&self) -> Vec<usize> {
+        self.selected_group_indices.iter().map(|x| self.groups.pool[*x].id).collect()
+    }
+
+    pub fn clear_group_selection(&mut self) {
+        self.selected_group_indices.clear()
+    }
 }
 
 impl Context {
@@ -544,6 +658,54 @@ impl Context {
         node.rect = response.response.rect.expand2(node.layout_style.padding);
         if response.response.hovered() || ui.rect_contains_pointer(node.rect) {
             self.node_indices_overlapping_with_mouse.push(idx);
+        }
+    }
+
+    fn add_group(
+        &mut self,
+        idx: usize,
+        GroupConstructor {
+            id,
+            title,
+            member_ids,
+            pos: _,
+            size: _,
+            args,
+        }: GroupConstructor<'_>,
+        ui: &mut egui::Ui,
+    ) {
+        self.style.format_group(&mut self.groups.pool[idx], args);
+        let group = &mut self.groups.pool[idx];
+        group.background_shape.replace(ui.painter().add(egui::Shape::Noop));
+        group.titlebar_shape.replace(ui.painter().add(egui::Shape::Noop));
+        group.outline_shape.replace(ui.painter().add(egui::Shape::Noop));
+        group.id = id;
+        let group_origin = group.origin;
+        let group_size = group.size;
+
+        let screen_min = self.grid_space_to_screen_space(group_origin);
+        let rect = egui::Rect::from_min_size(screen_min, group_size);
+        let title_bar_rect = egui::Rect::from_min_size(
+            rect.min,
+            egui::vec2(rect.width(), self.style.group_title_bar_height),
+        );
+        let group = &mut self.groups.pool[idx];
+        group.rect = rect;
+        group.title_bar_rect = title_bar_rect;
+
+        for mid in member_ids.iter() {
+            if let Some(node_idx) = self.nodes.find(*mid) {
+                self.groups.pool[idx].member_node_indices.push(node_idx);
+            }
+        }
+        self.groups.pool[idx].member_node_ids = member_ids;
+
+        if let Some(title) = title {
+            let padding = self.groups.pool[idx].layout_style.padding.x;
+            ui.scope_builder(
+                UiBuilder::new().max_rect(title_bar_rect.shrink2(egui::vec2(padding, 0.0))),
+                title,
+            );
         }
     }
 
@@ -621,6 +783,12 @@ impl Context {
             StyleVar::PinLineThickness => &mut self.style.pin_line_thickness,
             StyleVar::PinHoverRadius => &mut self.style.pin_hover_radius,
             StyleVar::PinOffset => &mut self.style.pin_offset,
+            StyleVar::GroupCornerRounding => &mut self.style.group_corner_rounding,
+            StyleVar::GroupPaddingHorizontal => &mut self.style.group_padding_horizontal,
+            StyleVar::GroupPaddingVertical => &mut self.style.group_padding_vertical,
+            StyleVar::GroupBorderThickness => &mut self.style.group_border_thickness,
+            StyleVar::GroupTitleBarHeight => &mut self.style.group_title_bar_height,
+            StyleVar::GroupResizeHandleSize => &mut self.style.group_resize_handle_size,
         }
     }
 
@@ -782,6 +950,36 @@ impl Context {
         }
     }
 
+    fn resolve_hovered_group(&mut self) {
+        self.hovered_group_index.take();
+        self.hovered_group_resize_handle = false;
+
+        for idx in self.group_depth_order.iter().rev() {
+            let idx = *idx;
+            if !self.groups.in_use[idx] {
+                continue;
+            }
+            let group = &self.groups.pool[idx];
+            if group.resizable {
+                let handle_size = egui::vec2(
+                    self.style.group_resize_handle_size,
+                    self.style.group_resize_handle_size,
+                );
+                let handle_rect =
+                    egui::Rect::from_min_size(group.rect.right_bottom() - handle_size, handle_size);
+                if handle_rect.contains(self.mouse_pos) {
+                    self.hovered_group_index.replace(idx);
+                    self.hovered_group_resize_handle = true;
+                    return;
+                }
+            }
+            if group.rect.contains(self.mouse_pos) {
+                self.hovered_group_index.replace(idx);
+                return;
+            }
+        }
+    }
+
     fn draw_link(&mut self, link_idx: usize, ui: &mut egui::Ui) {
         let link = &mut self.links.pool[link_idx];
         let start_pin = &self.pins.pool[link.start_pin_index];
@@ -867,13 +1065,67 @@ impl Context {
             );
         }
 
-        for pin_idx in node.pin_indices.clone() {
+        for i in 0..self.nodes.pool[node_idx].pin_indices.len() {
+            let pin_idx = self.nodes.pool[node_idx].pin_indices[i];
             self.draw_pin(pin_idx, ui);
         }
 
         if node_hovered && self.left_mouse_clicked && self.interactive_node_index != Some(node_idx)
         {
             self.begin_node_selection(node_idx);
+        }
+    }
+
+    fn draw_group(&mut self, group_idx: usize, ui: &mut egui::Ui) {
+        let group = &mut self.groups.pool[group_idx];
+
+        let group_hovered = self.hovered_group_index == Some(group_idx)
+            && self.click_interaction_type != ClickInteractionType::BoxSelection;
+
+        let mut background = group.color_style.background;
+        let mut titlebar = group.color_style.titlebar;
+
+        if self.selected_group_indices.contains(&group_idx) {
+            background = group.color_style.background_selected;
+            titlebar = group.color_style.titlebar_selected;
+        } else if group_hovered {
+            background = group.color_style.background_hovered;
+            titlebar = group.color_style.titlebar_hovered;
+        }
+
+        let painter = ui.painter();
+
+        painter.set(
+            group.background_shape.take().unwrap(),
+            egui::Shape::rect_filled(group.rect, group.layout_style.corner_rounding, background),
+        );
+        painter.set(
+            group.titlebar_shape.take().unwrap(),
+            egui::Shape::rect_filled(
+                group.title_bar_rect,
+                group.layout_style.corner_rounding,
+                titlebar,
+            ),
+        );
+        painter.set(
+            group.outline_shape.take().unwrap(),
+            egui::Shape::rect_stroke(
+                group.rect,
+                group.layout_style.corner_rounding,
+                (
+                    group.layout_style.border_thickness,
+                    group.color_style.outline,
+                ),
+                egui::StrokeKind::Inside,
+            ),
+        );
+
+        if group_hovered && self.left_mouse_clicked {
+            if self.hovered_group_resize_handle {
+                self.begin_group_resize(group_idx);
+            } else {
+                self.begin_group_selection(group_idx);
+            }
         }
     }
 
@@ -939,6 +1191,23 @@ impl Context {
                 let node = &mut self.nodes.pool[*idx];
                 if node.draggable {
                     node.origin += delta;
+                }
+            }
+        }
+    }
+
+    fn translate_selected_groups(&mut self) {
+        if self.left_mouse_dragging {
+            let delta = self.mouse_delta;
+            for idx in self.selected_group_indices.iter() {
+                let group = &mut self.groups.pool[*idx];
+                if group.draggable {
+                    group.origin += delta;
+                }
+            }
+            for idx in self.selected_group_indices.iter() {
+                for mi in self.groups.pool[*idx].member_node_indices.iter() {
+                    self.nodes.pool[*mi].origin += delta;
                 }
             }
         }
@@ -1173,6 +1442,28 @@ impl Context {
                     self.click_interaction_type = ClickInteractionType::None;
                 }
             }
+            ClickInteractionType::Group => {
+                self.translate_selected_groups();
+                if self.left_mouse_released {
+                    self.click_interaction_type = ClickInteractionType::None;
+                }
+            }
+            ClickInteractionType::GroupResize => {
+                if let Some(idx) = self.interactive_group_index.filter(|_| self.left_mouse_dragging)
+                {
+                    let delta = self.mouse_delta;
+                    let min_size = egui::vec2(
+                        self.style.group_resize_handle_size * 2.0,
+                        self.style.group_title_bar_height + self.style.group_resize_handle_size,
+                    );
+                    let group = &mut self.groups.pool[idx];
+                    group.size = (group.size + delta).max(min_size);
+                }
+                if self.left_mouse_released {
+                    self.click_interaction_type = ClickInteractionType::None;
+                    self.interactive_group_index = None;
+                }
+            }
             ClickInteractionType::None => (),
         }
     }
@@ -1259,6 +1550,28 @@ impl Context {
             self.node_depth_order.push(idx);
         }
     }
+
+    fn begin_group_selection(&mut self, idx: usize) {
+        if self.click_interaction_type != ClickInteractionType::None {
+            return;
+        }
+        self.click_interaction_type = ClickInteractionType::Group;
+        if !self.selected_group_indices.contains(&idx) {
+            self.selected_group_indices.clear();
+            self.selected_group_indices.push(idx);
+
+            self.group_depth_order.retain(|x| *x != idx);
+            self.group_depth_order.push(idx);
+        }
+    }
+
+    fn begin_group_resize(&mut self, idx: usize) {
+        if self.click_interaction_type != ClickInteractionType::None {
+            return;
+        }
+        self.click_interaction_type = ClickInteractionType::GroupResize;
+        self.interactive_group_index = Some(idx);
+    }
 }
 
 #[derive(Debug)]
@@ -1276,6 +1589,8 @@ enum ClickInteractionType {
     LinkCreation,
     Panning,
     BoxSelection,
+    Group,
+    GroupResize,
     None,
 }
 
@@ -1461,6 +1776,57 @@ impl Context {
             }
         };
         self.nodes.in_use[index] = true;
+        index
+    }
+
+    fn group_pool_update(&mut self) {
+        self.groups.free.clear();
+        for (i, (in_use, group)) in
+            self.groups.in_use.iter_mut().zip(self.groups.pool.iter_mut()).enumerate()
+        {
+            if *in_use {
+                group.member_node_indices.clear();
+            } else {
+                if self.groups.map.contains_key(&group.id) {
+                    self.group_depth_order.retain(|x| *x != i);
+                }
+                self.groups.map.remove(&group.id);
+                self.groups.free.push(i);
+            }
+        }
+    }
+
+    fn group_pool_find_or_create_index(
+        &mut self,
+        id: usize,
+        origin: Option<egui::Pos2>,
+        size: Option<egui::Vec2>,
+    ) -> usize {
+        let index = {
+            if let Some(index) = self.groups.find(id) {
+                index
+            } else {
+                let mut new_group = GroupData::new(id);
+                if let Some(origin) = origin {
+                    new_group.origin = self.screen_space_to_grid_space(origin);
+                }
+                if let Some(size) = size {
+                    new_group.size = size;
+                }
+                let index = if let Some(index) = self.groups.free.pop() {
+                    self.groups.pool[index] = new_group;
+                    index
+                } else {
+                    self.groups.pool.push(new_group);
+                    self.groups.in_use.push(false);
+                    self.groups.pool.len() - 1
+                };
+                self.groups.map.insert(id, index);
+                self.group_depth_order.push(index);
+                index
+            }
+        };
+        self.groups.in_use[index] = true;
         index
     }
 }

--- a/src/link.rs
+++ b/src/link.rs
@@ -3,7 +3,7 @@ use derivative::Derivative;
 use egui::epaint::PathShape;
 
 /// The Color Style of a Link. If feilds are None then the Context style is used
-#[derive(Default, Debug)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct LinkArgs {
     pub base: Option<egui::Color32>,
     pub hovered: Option<egui::Color32>,

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,5 +1,5 @@
 use super::*;
-use derivative::Derivative;
+use educe::Educe;
 use egui::epaint::PathShape;
 
 /// The Color Style of a Link. If feilds are None then the Context style is used
@@ -26,15 +26,15 @@ pub struct LinkDataColorStyle {
     pub hovered: egui::Color32,
     pub selected: egui::Color32,
 }
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Educe)]
+#[educe(Debug)]
 pub struct LinkData {
     pub id: usize,
     pub start_pin_index: usize,
     pub end_pin_index: usize,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub color_style: LinkDataColorStyle,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub shape: Option<egui::layers::ShapeIdx>,
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,5 +1,5 @@
 use super::*;
-use derivative::Derivative;
+use educe::Educe;
 
 #[derive(Default, Clone, Copy, Debug)]
 /// The Style of a Node. If feilds are None then the Context style is used
@@ -51,24 +51,24 @@ pub struct NodeDataLayoutStyle {
     pub border_thickness: f32,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Educe)]
+#[educe(Debug)]
 pub(crate) struct NodeData {
     pub id: usize,
     pub origin: egui::Pos2,
     pub size: egui::Vec2,
     pub title_bar_content_rect: egui::Rect,
     pub rect: egui::Rect,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub color_style: NodeDataColorStyle,
     pub layout_style: NodeDataLayoutStyle,
     pub pin_indices: Vec<usize>,
     pub draggable: bool,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub titlebar_shape: Option<egui::layers::ShapeIdx>,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub background_shape: Option<egui::layers::ShapeIdx>,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub outline_shape: Option<egui::layers::ShapeIdx>,
 }
 
@@ -108,15 +108,15 @@ impl Default for NodeData {
 
 /// Used to construct a node and stores the relevant ui code for its title and attributes
 /// This is used so that the nodes can be rendered in the context depth order
-#[derive(Derivative, Default)]
-#[derivative(Debug)]
+#[derive(Educe, Default)]
+#[educe(Debug)]
 #[allow(clippy::type_complexity)]
 pub struct NodeConstructor<'a> {
     //node: &'a mut NodeData,
     pub(crate) id: usize,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub(crate) title: Option<Box<dyn FnOnce(&mut egui::Ui) -> egui::Response + 'a>>,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub(crate) attributes: Vec<(
         usize,
         AttributeType,

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,7 +1,7 @@
 use super::*;
 use derivative::Derivative;
 
-#[derive(Default, Debug)]
+#[derive(Default, Clone, Copy, Debug)]
 /// The Style of a Node. If feilds are None then the Context style is used
 pub struct NodeArgs {
     pub background: Option<egui::Color32>,

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,7 +1,7 @@
 use super::*;
 use derivative::Derivative;
 
-#[derive(Default, Debug)]
+#[derive(Default, Clone, Copy, Debug)]
 /// The Visual Style of a Link.
 /// If feilds are None then the Context style is used.
 /// shape defualts to CircleFilled

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,5 +1,5 @@
 use super::*;
-use derivative::Derivative;
+use educe::Educe;
 
 #[derive(Default, Clone, Copy, Debug)]
 /// The Visual Style of a Link.
@@ -63,8 +63,8 @@ pub(crate) struct PinDataColorStyle {
     pub hovered: egui::Color32,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Educe)]
+#[educe(Debug)]
 pub(crate) struct PinData {
     pub id: usize,
     pub parent_node_idx: usize,
@@ -73,9 +73,9 @@ pub(crate) struct PinData {
     pub shape: PinShape,
     pub pos: egui::Pos2,
     pub flags: usize,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub color_style: PinDataColorStyle,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub shape_gui: Option<egui::layers::ShapeIdx>,
 }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -19,6 +19,13 @@ pub enum ColorStyle {
     BoxSelectorOutline,
     GridBackground,
     GridLine,
+    GroupBackground,
+    GroupBackgroundHovered,
+    GroupBackgroundSelected,
+    GroupOutline,
+    GroupTitleBar,
+    GroupTitleBarHovered,
+    GroupTitleBarSelected,
     Count,
 }
 
@@ -39,6 +46,12 @@ pub enum StyleVar {
     PinLineThickness,
     PinHoverRadius,
     PinOffset,
+    GroupCornerRounding,
+    GroupPaddingHorizontal,
+    GroupPaddingVertical,
+    GroupBorderThickness,
+    GroupTitleBarHeight,
+    GroupResizeHandleSize,
 }
 
 /// Controls some style aspects
@@ -64,9 +77,9 @@ impl ColorStyle {
         colors[ColorStyle::TitleBar as usize] =
             egui::Color32::from_rgba_unmultiplied(41, 74, 122, 255);
         colors[ColorStyle::TitleBarHovered as usize] =
-            egui::Color32::from_rgba_unmultiplied(66, 150, 250, 255);
+            egui::Color32::from_rgba_unmultiplied(58, 100, 162, 255);
         colors[ColorStyle::TitleBarSelected as usize] =
-            egui::Color32::from_rgba_unmultiplied(66, 150, 250, 255);
+            egui::Color32::from_rgba_unmultiplied(62, 106, 170, 255);
         colors[ColorStyle::Link as usize] =
             egui::Color32::from_rgba_unmultiplied(61, 133, 224, 200);
         colors[ColorStyle::LinkHovered as usize] =
@@ -84,6 +97,20 @@ impl ColorStyle {
             egui::Color32::from_rgba_unmultiplied(40, 40, 50, 200);
         colors[ColorStyle::GridLine as usize] =
             egui::Color32::from_rgba_unmultiplied(200, 200, 200, 40);
+        colors[ColorStyle::GroupBackground as usize] =
+            egui::Color32::from_rgba_unmultiplied(40, 40, 40, 120);
+        colors[ColorStyle::GroupBackgroundHovered as usize] =
+            egui::Color32::from_rgba_unmultiplied(55, 55, 55, 140);
+        colors[ColorStyle::GroupBackgroundSelected as usize] =
+            egui::Color32::from_rgba_unmultiplied(55, 55, 55, 160);
+        colors[ColorStyle::GroupOutline as usize] =
+            egui::Color32::from_rgba_unmultiplied(100, 100, 100, 200);
+        colors[ColorStyle::GroupTitleBar as usize] =
+            egui::Color32::from_rgba_unmultiplied(41, 74, 122, 180);
+        colors[ColorStyle::GroupTitleBarHovered as usize] =
+            egui::Color32::from_rgba_unmultiplied(58, 100, 162, 200);
+        colors[ColorStyle::GroupTitleBarSelected as usize] =
+            egui::Color32::from_rgba_unmultiplied(62, 106, 170, 220);
         colors
     }
 
@@ -121,6 +148,20 @@ impl ColorStyle {
             egui::Color32::from_rgba_unmultiplied(40, 40, 50, 200);
         colors[ColorStyle::GridLine as usize] =
             egui::Color32::from_rgba_unmultiplied(200, 200, 200, 40);
+        colors[ColorStyle::GroupBackground as usize] =
+            egui::Color32::from_rgba_unmultiplied(50, 50, 50, 120);
+        colors[ColorStyle::GroupBackgroundHovered as usize] =
+            egui::Color32::from_rgba_unmultiplied(75, 75, 75, 140);
+        colors[ColorStyle::GroupBackgroundSelected as usize] =
+            egui::Color32::from_rgba_unmultiplied(75, 75, 75, 160);
+        colors[ColorStyle::GroupOutline as usize] =
+            egui::Color32::from_rgba_unmultiplied(100, 100, 100, 200);
+        colors[ColorStyle::GroupTitleBar as usize] =
+            egui::Color32::from_rgba_unmultiplied(69, 69, 138, 180);
+        colors[ColorStyle::GroupTitleBarHovered as usize] =
+            egui::Color32::from_rgba_unmultiplied(82, 82, 161, 200);
+        colors[ColorStyle::GroupTitleBarSelected as usize] =
+            egui::Color32::from_rgba_unmultiplied(82, 82, 161, 220);
         colors
     }
 
@@ -158,6 +199,20 @@ impl ColorStyle {
             egui::Color32::from_rgba_unmultiplied(225, 225, 225, 255);
         colors[ColorStyle::GridLine as usize] =
             egui::Color32::from_rgba_unmultiplied(180, 180, 180, 100);
+        colors[ColorStyle::GroupBackground as usize] =
+            egui::Color32::from_rgba_unmultiplied(220, 220, 220, 140);
+        colors[ColorStyle::GroupBackgroundHovered as usize] =
+            egui::Color32::from_rgba_unmultiplied(210, 210, 210, 160);
+        colors[ColorStyle::GroupBackgroundSelected as usize] =
+            egui::Color32::from_rgba_unmultiplied(200, 200, 200, 180);
+        colors[ColorStyle::GroupOutline as usize] =
+            egui::Color32::from_rgba_unmultiplied(100, 100, 100, 200);
+        colors[ColorStyle::GroupTitleBar as usize] =
+            egui::Color32::from_rgba_unmultiplied(248, 248, 248, 200);
+        colors[ColorStyle::GroupTitleBarHovered as usize] =
+            egui::Color32::from_rgba_unmultiplied(209, 209, 209, 220);
+        colors[ColorStyle::GroupTitleBarSelected as usize] =
+            egui::Color32::from_rgba_unmultiplied(209, 209, 209, 240);
         colors
     }
 }
@@ -189,6 +244,13 @@ pub struct Style {
     pub pin_hover_radius: f32,
     pub pin_offset: f32,
 
+    pub group_corner_rounding: f32,
+    pub group_padding_horizontal: f32,
+    pub group_padding_vertical: f32,
+    pub group_border_thickness: f32,
+    pub group_title_bar_height: f32,
+    pub group_resize_handle_size: f32,
+
     pub flags: usize,
     pub colors: [egui::Color32; ColorStyle::Count as usize],
 }
@@ -210,6 +272,12 @@ impl Default for Style {
             pin_line_thickness: 1.0,
             pin_hover_radius: 10.0,
             pin_offset: 0.0,
+            group_corner_rounding: 4.0,
+            group_padding_horizontal: 8.0,
+            group_padding_vertical: 8.0,
+            group_border_thickness: 1.0,
+            group_title_bar_height: 24.0,
+            group_resize_handle_size: 12.0,
             flags: StyleFlags::NodeOutline as usize | StyleFlags::GridLines as usize,
             colors: ColorStyle::colors_dark(),
         }
@@ -337,6 +405,33 @@ impl Style {
         });
         node.layout_style.border_thickness =
             args.border_thickness.unwrap_or(self.node_border_thickness);
+    }
+
+    pub(crate) fn format_group(&self, group: &mut GroupData, args: GroupArgs) {
+        group.color_style.background =
+            args.background.unwrap_or(self.colors[ColorStyle::GroupBackground as usize]);
+        group.color_style.background_hovered = args
+            .background_hovered
+            .unwrap_or(self.colors[ColorStyle::GroupBackgroundHovered as usize]);
+        group.color_style.background_selected = args
+            .background_selected
+            .unwrap_or(self.colors[ColorStyle::GroupBackgroundSelected as usize]);
+        group.color_style.outline =
+            args.outline.unwrap_or(self.colors[ColorStyle::GroupOutline as usize]);
+        group.color_style.titlebar =
+            args.titlebar.unwrap_or(self.colors[ColorStyle::GroupTitleBar as usize]);
+        group.color_style.titlebar_hovered =
+            args.titlebar_hovered.unwrap_or(self.colors[ColorStyle::GroupTitleBarHovered as usize]);
+        group.color_style.titlebar_selected = args
+            .titlebar_selected
+            .unwrap_or(self.colors[ColorStyle::GroupTitleBarSelected as usize]);
+        group.layout_style.corner_rounding =
+            args.corner_rounding.unwrap_or(self.group_corner_rounding);
+        group.layout_style.padding = args.padding.unwrap_or_else(|| {
+            egui::vec2(self.group_padding_horizontal, self.group_padding_vertical)
+        });
+        group.layout_style.border_thickness =
+            args.border_thickness.unwrap_or(self.group_border_thickness);
     }
 
     pub(crate) fn format_pin(&self, pin: &mut PinData, args: PinArgs, flags: usize) {


### PR DESCRIPTION
Add node groups and clean up the example files. This PR is inspired by Unreal Engine's comment groups.
Also remove the dependency on the unmaintained derivative crate.
Closes #6 